### PR TITLE
ruby 2.3.0 での timeoutエラーの対処

### DIFF
--- a/check-cloudwatch.rb
+++ b/check-cloudwatch.rb
@@ -151,7 +151,7 @@ class CheckCloudWatch < Sensu::Plugin::Check::CLI
     @own_region ||= begin
       require "net/http"
 
-      timeout 3 do
+      Timeout.timeout 3 do
         Net::HTTP.get("169.254.169.254", "/latest/meta-data/placement/availability-zone").chop
       end
     rescue

--- a/check-cloudwatch.rb
+++ b/check-cloudwatch.rb
@@ -2,6 +2,7 @@
 
 require "sensu-plugin/check/cli"
 require "aws-sdk-core"
+require "timeout"
 
 class CheckCloudWatch < Sensu::Plugin::Check::CLI
   VERSION = "0.2.0"


### PR DESCRIPTION
check-cloudwatch.rb:154:in `own_region': Object#timeout is deprecated, use Timeout.timeout instead.